### PR TITLE
impl std::error::Error for QueryCompilationError

### DIFF
--- a/src/grammer.pest
+++ b/src/grammer.pest
@@ -69,4 +69,4 @@ query = _{SOI ~ "$" ~ root? ~ EOI}
 
 simple_query = _{SOI ~ "$" ~ simple_root ~ EOI}
 
-WHITESPACE = _{ " " }
+WHITESPACE = _{ " " | "\r\n" | "\n" | "\r" | "\t" }

--- a/src/json_path.rs
+++ b/src/json_path.rs
@@ -21,6 +21,8 @@ pub struct QueryCompilationError {
     message: String,
 }
 
+impl std::error::Error for QueryCompilationError {}
+
 impl std::fmt::Display for QueryCompilationError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         write!(

--- a/tests/filter.rs
+++ b/tests/filter.rs
@@ -319,3 +319,12 @@ fn unimplemented_in_filter() {
         json!([]),
     );
 }
+
+#[test]
+fn whitespace() {
+    select_and_then_compare(
+        "$\n[\r?\t(\r\n@\r.a == 1)]",
+        json!({"a": 1}),
+        json!([{"a" : 1}]),
+    );
+}


### PR DESCRIPTION
Required for the ability to be used together with `thiserror`.
Should not hurt anyway :slightly_smiling_face: 