### PR TITLE
Implement `Error` for `QueryCompilationError`

### DIFF
--- a/src/json_path.rs
+++ b/src/json_path.rs
@@ -100,6 +100,8 @@ impl std::fmt::Display for QueryCompilationError {
     }
 }
 
+impl std::error::Error for QueryCompilationError {}
+
 impl std::fmt::Display for Rule {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match self {


### PR DESCRIPTION
Hello, since you already implemented `Display` for `QueryCompilationError`, I thought it would be great to also implement `std::error::Error`. With this people can use the `?` operator with the errors returned, for example.

This is what I did in this PR.